### PR TITLE
add realistic lantern holding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _________________
 - Moss on mossy stone bricks changing colour depending on biome (compatible with FAT!)
 - Intersecting planks and bricks using CTM overlays (by @RobertRR11; currently not compatible with FAT, will be in the future)
 - Blackstone furnaces in the nether (by @RobertRR11; blast furnace and smoker not done)
+- realistic lantern holding (by @RobertRR11)
 ### Partially implemented features
 - Container-specific GUI
 - CTM overlay textures (will be reworked in the future)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ _________________
 - Bedrock looking more similar to netherrack in the nether
 - Better flower pots (by @RobertRR11; compatible with Faithful 3D only partially)
 - Moss on mossy stone bricks changing colour depending on biome (compatible with FAT!)
-- Intersecting planks and bricks using CTM overlays (by @RobertRR11; currently not compatible with FAT, will be in the future)
-- Blackstone furnaces in the nether (by @RobertRR11; blast furnace and smoker not done)
-- realistic lantern holding (by @RobertRR11)
+- Dungeons-like terracotta in badlands biomes
+- Realistic lantern holding (by @RobertRR11)
 ### Partially implemented features
 - Container-specific GUI
 - CTM overlay textures (will be reworked in the future)
 - Better slab sides
+- Blackstone furnaces in the nether (by @RobertRR11; blast furnace and smoker not done)
+- Intersecting planks and bricks using CTM overlays (by @RobertRR11 and @Pomik108; currently not compatible with FAT, will be in the future)
 ### Planned features
 - Oak logs and leaves looking different in swamps
 - Biome- and height-dependent creeper textures
@@ -41,6 +42,5 @@ _________________
 - Better farmland
 - Crimson/warped mossy polished blackstone bricks as a rare variant of polished blackstone bricks in crimson/warped forests
 - Differentiated potions (ala [this pack](https://www.curseforge.com/minecraft/texture-packs/color-corkination))
-- Dungeons-like terracotta in badlands biomes
 - Better smooth stone
 - Flowers and berry bushes using the grass colourmap

--- a/assets/minecraft/models/item/lantern.json
+++ b/assets/minecraft/models/item/lantern.json
@@ -1,0 +1,43 @@
+{
+	"parent": "block/lantern",
+	"display": {
+		"gui": {
+            "rotation": [ 30, 225, 0 ],
+            "translation": [ 0, 2, 0 ],
+            "scale":[ 1, 1, 1 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 3, 0 ],
+            "scale":[ 0.65, 0.65, 0.65 ]
+        },
+		"fixed": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale":[ 1, 1, 1 ]
+        },
+		"head": {
+			"translation": [0, 14.4, 0]
+		},
+		"thirdperson_righthand": {
+			"rotation": [66, 0, 0],
+			"translation": [0, -0.7, -1.5],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [66, 0, 0],
+			"translation": [0, -0.7, -1.5],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"firstperson_righthand": {
+			"rotation": [-5, 20, 5],
+			"translation": [1.5, 4, 0],
+			"scale": [0.6, 0.6, 0.6]
+		},
+		"firstperson_lefthand": {
+			"rotation": [-5, 20, 5],
+			"translation": [1.5, 4, 0],
+			"scale": [0.6, 0.6, 0.6]
+		}
+	}
+}

--- a/assets/minecraft/models/item/soul_lantern.json
+++ b/assets/minecraft/models/item/soul_lantern.json
@@ -1,0 +1,43 @@
+{
+	"parent": "block/soul_lantern",
+	"display": {
+		"gui": {
+            "rotation": [ 30, 225, 0 ],
+            "translation": [ 0, 2, 0 ],
+            "scale":[ 1, 1, 1 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 3, 0 ],
+            "scale":[ 0.65, 0.65, 0.65 ]
+        },
+		"fixed": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale":[ 1, 1, 1 ]
+        },
+		"head": {
+			"translation": [0, 14.4, 0]
+		},
+		"thirdperson_righthand": {
+			"rotation": [66, 0, 0],
+			"translation": [0, -0.7, -1.5],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [66, 0, 0],
+			"translation": [0, -0.7, -1.5],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"firstperson_righthand": {
+			"rotation": [-5, 20, 5],
+			"translation": [1.5, 4, 0],
+			"scale": [0.6, 0.6, 0.6]
+		},
+		"firstperson_lefthand": {
+			"rotation": [-5, 20, 5],
+			"translation": [1.5, 4, 0],
+			"scale": [0.6, 0.6, 0.6]
+		}
+	}
+}


### PR DESCRIPTION
when holding in third person:
![third_person](https://user-images.githubusercontent.com/57044042/94572374-3cd3b700-0271-11eb-8ef5-6537703bf40b.png)

when holding in first person + inventory icon:
![first_person](https://user-images.githubusercontent.com/57044042/94572433-4e1cc380-0271-11eb-9b9b-9ee1cf41a034.png)

when placing on head with command "/replaceitem entity @p armor.head minecraft:lantern":
![on_head](https://user-images.githubusercontent.com/57044042/94572490-6260c080-0271-11eb-8a95-ce2bb5698ca7.png)
